### PR TITLE
Resource references should now be capitalised

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,7 @@ registry::value { 'ipv6':
 if $ipv6_reboot {
 # Monitor for changes to ipv6 registry to determine whether a system restart is required
 reboot { 'after':
-  subscribe => registry::value['ipv6'],
+  subscribe => Registry::Value['ipv6'],
   }
   }
   else{


### PR DESCRIPTION
Updated so up to date syntax is used. Now lints without warning or error
